### PR TITLE
Describe where to get Java 11

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -99,6 +99,9 @@ Your solution should focus on **maintainability**, **reusability** and
 
 == Getting started
 
+=== Install Java
+For this project, the Java Development Kit 11 or above is required. You can download it from https://adoptopenjdk.net/.
+
 === Getting a copy
 The starting point for every challenge is provided as a branch in a Gitlab.com/GitHub
 hosted Git repository. Be careful to adjust the URLs below


### PR DESCRIPTION
Ein Bewerber hat einige Zeit damit verbracht, das Projekt mit Java 8 zu starten. Java 11 steht zwar im Maven POM, es ist aber sicher hilfreich, es nochmal zu erwähnen, falls Bewerber*innen nicht so firm mit maven sind (was ich nicht voraussetzen würde).